### PR TITLE
Fix object duplication in type list when object already is in the type list

### DIFF
--- a/src/meta_planning/parsers/model_parsing.py
+++ b/src/meta_planning/parsers/model_parsing.py
@@ -225,8 +225,13 @@ def parse_model(model_file):
         if field == ":requirements":
             requirements = Requirements(opt[1:])
         elif field == ":types":
-            the_types.extend(parse_typed_list(
-                    opt[1:], constructor=Type))
+            types = parse_typed_list(
+                    opt[1:], constructor=Type)
+            
+            if types[0].name == the_types[0].name:
+                types[0].pop(0)
+            
+            the_types.extend(types)
         elif field == ":constants":
             constants = parse_typed_list(opt[1:])
         elif field == ":predicates":

--- a/src/meta_planning/parsers/model_parsing.py
+++ b/src/meta_planning/parsers/model_parsing.py
@@ -229,7 +229,7 @@ def parse_model(model_file):
                     opt[1:], constructor=Type)
             
             if types[0].name == the_types[0].name:
-                types[0].pop(0)
+                types.pop(0)
             
             the_types.extend(types)
         elif field == ":constants":

--- a/src/meta_planning/parsers/solution_parsing.py
+++ b/src/meta_planning/parsers/solution_parsing.py
@@ -27,7 +27,7 @@ def build_model(pres, effs, initial_model):
 
             eff += [Effect([], Truth(), Literal(e[0],[arg.replace("var", "?o") for arg in e[1:]], valuation))]
 
-        learned_model.schemata += [Scheme(scheme.name, scheme.parameters, len(scheme.parameters), Conjunction(pre), eff, 0)]
+        learned_model.schemata += [Scheme(scheme.name, scheme.parameters, len(scheme.parameters), Conjunction(pre), eff, None)]
 
 
     return learned_model


### PR DESCRIPTION
This happens when a model is saved to file and parsed back, since it adds object to the list of types when it saves to file.