### PR TITLE
Fix object duplication in type list when object already is in the type list

### DIFF
--- a/src/meta_planning/parsers/model_parsing.py
+++ b/src/meta_planning/parsers/model_parsing.py
@@ -225,8 +225,13 @@ def parse_model(model_file):
         if field == ":requirements":
             requirements = Requirements(opt[1:])
         elif field == ":types":
-            the_types.extend(parse_typed_list(
-                    opt[1:], constructor=Type))
+            types = parse_typed_list(
+                    opt[1:], constructor=Type)
+            
+            if types[0].name == the_types[0].name:
+                types.pop()
+            
+            the_types.extend(types)
         elif field == ":constants":
             constants = parse_typed_list(opt[1:])
         elif field == ":predicates":


### PR DESCRIPTION
This happens when a model is saved to file and parsed back, since it adds object to the list of types when it saves to file.