### PR TITLE
Replace cost 0 with None

### DIFF
--- a/src/meta_planning/parsers/solution_parsing.py
+++ b/src/meta_planning/parsers/solution_parsing.py
@@ -27,7 +27,7 @@ def build_model(pres, effs, initial_model):
 
             eff += [Effect([], Truth(), Literal(e[0],[arg.replace("var", "?o") for arg in e[1:]], valuation))]
 
-        learned_model.schemata += [Scheme(scheme.name, scheme.parameters, len(scheme.parameters), Conjunction(pre), eff, 0)]
+        learned_model.schemata += [Scheme(scheme.name, scheme.parameters, len(scheme.parameters), Conjunction(pre), eff, None)]
 
 
     return learned_model


### PR DESCRIPTION
Possibly a bug, since in every other place it uses None or copies from somewhere else. This caused a learned model to have the cost appended to every action scheme, producing a parsing error (perhaps the format of the cost information is also being generated incorrectly, since it just prints the number but expects something else when parsing).