### PR TITLE
Make build_model use the actual variable names in literals instead of generic ones

### DIFF
--- a/src/meta_planning/parsers/solution_parsing.py
+++ b/src/meta_planning/parsers/solution_parsing.py
@@ -17,7 +17,7 @@ def build_model(pres, effs, initial_model):
 
         for p in pres[name]:
             p = list(p)
-            pre += [Literal(p[0], [arg.replace("var", "?o") for arg in p[1:]], True)]
+            pre += [Literal(p[0], [scheme.parameters[int(arg.replace("var", "")) - 1].name for arg in p[1:]], True)]
 
         for e in effs[name]:
             if e in pres[name]:
@@ -25,7 +25,7 @@ def build_model(pres, effs, initial_model):
             else:
                 valuation = True
 
-            eff += [Effect([], Truth(), Literal(e[0],[arg.replace("var", "?o") for arg in e[1:]], valuation))]
+            eff += [Effect([], Truth(), Literal(e[0],[scheme.parameters[int(arg.replace("var", "")) - 1].name for arg in e[1:]], valuation))]
 
         learned_model.schemata += [Scheme(scheme.name, scheme.parameters, len(scheme.parameters), Conjunction(pre), eff, 0)]
 


### PR DESCRIPTION
This is a bug, as the produced model will have invalid variable names when the variable names don't match the generic ones.